### PR TITLE
Google Health API: full data-type mapping + paginated intraday fetch

### DIFF
--- a/Fitbit_Fetch.py
+++ b/Fitbit_Fetch.py
@@ -644,10 +644,41 @@ def get_user_timezone_name():
     return "UTC"
 
 
+def discover_google_device_name():
+    """Inspect a few popular data types and return the first dataSource.device.displayName
+    we can find (e.g. "Versa 4"). Google attaches device metadata to every data point even
+    though it does not expose battery telemetry. Returns None if nothing usable is found."""
+    for data_type in ("heart-rate", "steps", "daily-resting-heart-rate", "weight", "exercise"):
+        try:
+            resp = request_google_data_points_list(
+                data_type, params={"pageSize": 1}, suppress_http_error_log=True
+            )
+        except requests.exceptions.HTTPError:
+            continue
+        if not isinstance(resp, dict):
+            continue
+        for dp in resp.get("dataPoints", []):
+            device = (dp.get("dataSource") or {}).get("device") or {}
+            name = device.get("displayName")
+            if name:
+                return name.strip()
+    return None
+
+
 if LOCAL_TIMEZONE == "Automatic":
     LOCAL_TIMEZONE = pytz.timezone(get_user_timezone_name())
 else:
     LOCAL_TIMEZONE = pytz.timezone(LOCAL_TIMEZONE)
+
+# Auto-detect the device name from the Google Health API if the user did not set
+# DEVICENAME explicitly. Falls back silently to the placeholder if discovery fails.
+if HEALTH_API_PROVIDER == "google" and DEVICENAME == "Your_Device_Name":
+    discovered_device_name = discover_google_device_name()
+    if discovered_device_name:
+        logging.info("Auto-detected Google device displayName: %s (override with DEVICENAME env var)", discovered_device_name)
+        DEVICENAME = discovered_device_name
+    else:
+        logging.info("Could not auto-detect device displayName from Google Health API; keeping default '%s'", DEVICENAME)
 
 # %% [markdown]
 # ## Selecting Dates for update

--- a/Fitbit_Fetch.py
+++ b/Fitbit_Fetch.py
@@ -1122,6 +1122,19 @@ def get_daily_data_limit_30d(start_date_str, end_date_str):
         logging.error("Recording failed : weight and BMI for date " + start_date_str + " to " + end_date_str)
 
 
+# Anchor a sleep session to the day the user conceptually went to bed, so it buckets
+# correctly in Grafana regardless of how late they fell asleep or which timezone the
+# dashboard is viewed in. Rule: if start time in local TZ is < noon (post-midnight
+# sleep), the session belongs to the previous local day; otherwise the local day.
+# Returns ISO at 12:00 UTC of that sleep date — stable for any viewer TZ within ±12h.
+def compute_sleep_date_anchor_ts(start_dt, local_tz):
+    if start_dt.tzinfo is None:
+        start_dt = local_tz.localize(start_dt)
+    local_dt = start_dt.astimezone(local_tz)
+    sleep_date = local_dt.date() - timedelta(days=1) if local_dt.hour < 12 else local_dt.date()
+    return datetime(sleep_date.year, sleep_date.month, sleep_date.day, 12, 0, 0, tzinfo=pytz.utc).isoformat()
+
+
 # Sleep data — limit 100 days
 def get_daily_data_limit_100d(start_date_str, end_date_str):
     # Google sleep endpoint: data_type = "sleep", session record
@@ -1162,9 +1175,15 @@ def get_daily_data_limit_100d(start_date_str, end_date_str):
 
             is_main_sleep = sleep.get("metadata", {}).get("processed", True)
 
+            try:
+                start_dt_utc = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                summary_ts = compute_sleep_date_anchor_ts(start_dt_utc, LOCAL_TIMEZONE)
+            except (ValueError, AttributeError):
+                summary_ts = ts
+
             collected_records.append({
                 "measurement": "Sleep Summary",
-                "time": ts,
+                "time": summary_ts,
                 "tags": {"Device": DEVICENAME, "isMainSleep": is_main_sleep},
                 "fields": {
                     "efficiency":            efficiency,
@@ -1236,7 +1255,7 @@ def get_daily_data_limit_100d(start_date_str, end_date_str):
     if sleep_data != None:
         for record in sleep_data:
             log_time = datetime.fromisoformat(record["startTime"])
-            utc_time = LOCAL_TIMEZONE.localize(log_time).astimezone(pytz.utc).isoformat()
+            summary_time = compute_sleep_date_anchor_ts(log_time, LOCAL_TIMEZONE)
             try:
                 minutesLight = record['levels']['summary']['light']['minutes']
                 minutesREM   = record['levels']['summary']['rem']['minutes']
@@ -1245,10 +1264,10 @@ def get_daily_data_limit_100d(start_date_str, end_date_str):
                 minutesLight = record['levels']['summary']['asleep']['minutes']
                 minutesREM   = record['levels']['summary']['restless']['minutes']
                 minutesDeep  = 0
- 
+
             collected_records.append({
                     "measurement":  "Sleep Summary",
-                    "time": utc_time,
+                    "time": summary_time,
                     "tags": {
                         "Device": DEVICENAME,
                         "isMainSleep": record["isMainSleep"],

--- a/Fitbit_Fetch.py
+++ b/Fitbit_Fetch.py
@@ -316,24 +316,50 @@ def get_google_datapoints_for_date(data_type, date_str, page_size=10000):
         # Daily and unsupported data types often reject member-based filters.
         filters_to_try = []
 
-    response = None
+    # Google caps responses at ~5000 points per page regardless of pageSize, so we must
+    # follow nextPageToken to avoid silently dropping data (e.g. HR samples earlier in the day).
+    def _paginate(extra_params):
+        all_points = []
+        page_token = None
+        first = True
+        for _ in range(50):  # safety cap; one day of HR is ~17k samples → ~4 pages
+            params = dict(extra_params)
+            params["pageSize"] = page_size
+            if page_token:
+                params["pageToken"] = page_token
+            try:
+                resp = request_google_data_points_list(
+                    data_type, params=params, suppress_http_error_log=first
+                )
+            except requests.exceptions.HTTPError:
+                if first:
+                    raise
+                logging.warning("Pagination interrupted for %s; keeping %d points", data_type, len(all_points))
+                break
+            first = False
+            if not isinstance(resp, dict):
+                break
+            all_points.extend(resp.get("dataPoints", []))
+            page_token = resp.get("nextPageToken")
+            if not page_token:
+                break
+        return all_points
+
+    points = None
     used_server_filter = False
     for filter_expr in filters_to_try:
         try:
-            response = request_google_data_points_list(
-                data_type,
-                params={"pageSize": page_size, "filter": filter_expr},
-                suppress_http_error_log=True,
-            )
+            points = _paginate({"filter": filter_expr})
             used_server_filter = True
             break
         except requests.exceptions.HTTPError:
             continue
 
-    if response is None:
-        response = request_google_data_points_list(data_type, params={"pageSize": page_size})
-
-    points = response.get("dataPoints", []) if isinstance(response, dict) else []
+    if points is None:
+        try:
+            points = _paginate({})
+        except requests.exceptions.HTTPError:
+            points = []
     filtered = []
     for data_point in points:
         ts = parse_google_datapoint_timestamp(data_point, data_type)
@@ -734,13 +760,216 @@ def get_intraday_data_limit_1d(date_str, measurement_list):
             logging.info("Recorded " +  measurement[1] + " intraday for date " + date_str)
         else:
             logging.error("Recording failed : " +  measurement[1] + " intraday for date " + date_str)
-
-# Max range is 30 days, records BR, SPO2 Intraday, skin temp and HRV - 4 queries
+# =============================================================================
+# PATCH: Google Health API mappings for previously-skipped data types
+#
+# Drop-in replacements for three functions in Fitbit_Fetch.py:
+#   - get_daily_data_limit_30d   → HRV, Breathing Rate, Skin Temp, SPO2 intraday, Weight/BMI
+#   - get_daily_data_limit_100d  → Sleep Summary + Sleep Levels
+#   - get_daily_data_limit_365d  → Resting HR, HR Zones, Activity Minutes, Steps/Calories/Distance
+#
+# All Google endpoints used are from the official Google Health API docs:
+# https://developers.google.com/health/data-types
+#
+# Measurement names are kept identical to the Fitbit originals so the
+# existing Grafana dashboard works without changes.
+# =============================================================================
+ 
+# Max range is 30 days — HRV, BR, Skin Temp, SPO2 intraday, Weight/BMI
 def get_daily_data_limit_30d(start_date_str, end_date_str):
     if HEALTH_API_PROVIDER == "google":
-        logging.warning("Google mapping for 30-day grouped datasets (HRV/BR/SkinTemp/SPO2 intraday/weight) is not finalized yet. Skipping this batch.")
-        return
+ 
+        # --- HRV (daily-heart-rate-variability) ---
+        # Google field: dailyHeartRateVariability → { averageHeartRateVariabilityMilliseconds, deepSleepRootMeanSquareOfSuccessiveDifferencesMilliseconds, nonRemHeartRateBeatsPerMinute, entropy }
+        try:
+            points = get_google_datapoints_for_date_range("daily-heart-rate-variability", start_date_str, end_date_str)
+        except requests.exceptions.HTTPError as e:
+            logging.error("Google HRV fetch failed: %s", str(e))
+            points = []
+        inserted_count = 0
+        for data_point, ts in points:
+            hrv_fields = data_point.get("dailyHeartRateVariability", {})
+            rmssd      = extract_first_numeric(hrv_fields.get("averageHeartRateVariabilityMilliseconds"))
+            deep_rmssd = extract_first_numeric(hrv_fields.get("deepSleepRootMeanSquareOfSuccessiveDifferencesMilliseconds"))
+            non_rem_hr = extract_first_numeric(hrv_fields.get("nonRemHeartRateBeatsPerMinute"))
+            entropy    = extract_first_numeric(hrv_fields.get("entropy"))
+            if rmssd is None and deep_rmssd is None:
+                continue
+            fields = {}
+            if rmssd is not None:
+                fields["dailyRmssd"] = rmssd        # matches existing Grafana panel
+            if deep_rmssd is not None:
+                fields["deepRmssd"] = deep_rmssd    # matches existing Grafana panel
+            if non_rem_hr is not None:
+                fields["nonRemHeartRateBpm"] = non_rem_hr   # new — Google-only field
+            if entropy is not None:
+                fields["entropy"] = entropy                  # new — Google-only field
+            collected_records.append({
+                "measurement": "HRV",
+                "time": ts,
+                "tags": {"Device": DEVICENAME},
+                "fields": fields,
+            })
+            inserted_count += 1
+        if inserted_count:
+            logging.info("Recorded HRV for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No HRV records found for date %s to %s in Google mode", start_date_str, end_date_str)
+ 
+        # --- Breathing Rate (daily-respiratory-rate) ---
+        # Google field: dailyRespiratoryRate → { value } (breaths/min)
+        try:
+            points = get_google_datapoints_for_date_range("daily-respiratory-rate", start_date_str, end_date_str)
+        except requests.exceptions.HTTPError as e:
+            logging.error("Google Breathing Rate fetch failed: %s", str(e))
+            points = []
+        inserted_count = 0
+        for data_point, ts in points:
+            br_fields = data_point.get("dailyRespiratoryRate", {})
+            value = extract_first_numeric(br_fields.get("breathsPerMinute"))
+            if value is None:
+                continue
+            collected_records.append({
+                "measurement": "BreathingRate",
+                "time": ts,
+                "tags": {"Device": DEVICENAME},
+                "fields": {"value": float(value)},
+            })
+            inserted_count += 1
+        if inserted_count:
+            logging.info("Recorded BR for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No Breathing Rate records found for date %s to %s in Google mode", start_date_str, end_date_str)
+ 
+        # --- Skin Temperature Variation (daily-sleep-temperature-derivations) ---
+        # Google field: dailySleepTemperatureDerivations → { nightlyRelative }
+        try:
+            points = get_google_datapoints_for_date_range("daily-sleep-temperature-derivations", start_date_str, end_date_str)
+        except requests.exceptions.HTTPError as e:
+            logging.error("Google Skin Temp fetch failed: %s", str(e))
+            points = []
+        inserted_count = 0
+        for data_point, ts in points:
+            temp_fields = data_point.get("dailySleepTemperatureDerivations", {})
+            nightly  = extract_first_numeric(temp_fields.get("nightlyTemperatureCelsius"))
+            baseline = extract_first_numeric(temp_fields.get("baselineTemperatureCelsius"))
+            relative = round(nightly - baseline, 4) if nightly is not None and baseline is not None else None
+            stddev   = extract_first_numeric(temp_fields.get("relativeNightlyStddev30dCelsius"))
+            if relative is None:
+                continue
+            fields = {"RelativeValue": relative}
+            if stddev is not None:
+                fields["stddev30d"] = stddev
+            if nightly is not None:
+                fields["nightlyTemperatureCelsius"] = nightly
+            if baseline is not None:
+                fields["baselineTemperatureCelsius"] = baseline
+            collected_records.append({
+                "measurement": "Skin Temperature Variation",
+                "time": ts,
+                "tags": {"Device": DEVICENAME},
+                "fields": fields,
+            })
+            inserted_count += 1
+        if inserted_count:
+            logging.info("Recorded Skin Temperature Variation for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No Skin Temp records found for date %s to %s in Google mode", start_date_str, end_date_str)
+ 
+        # --- SPO2 Intraday (oxygen-saturation — instantaneous samples) ---
+        # Google field: oxygenSaturation → { percentage }
+        # Uses sample_time filter (same as heart-rate), walks day by day
+        try:
+            points = get_google_datapoints_for_date_range("oxygen-saturation", start_date_str, end_date_str)
+        except requests.exceptions.HTTPError as e:
+            logging.error("Google SPO2 intraday fetch failed: %s", str(e))
+            points = []
+        inserted_count = 0
+        for data_point, ts in points:
+            spo2_fields = data_point.get("oxygenSaturation", {})
+            value = extract_first_numeric(spo2_fields.get("percentage")) or extract_first_numeric(spo2_fields)
+            if value is None:
+                continue
+            collected_records.append({
+                "measurement": "SPO2_Intraday",
+                "time": ts,
+                "tags": {"Device": DEVICENAME},
+                "fields": {"value": float(value)},
+            })
+            inserted_count += 1
+        if inserted_count:
+            logging.info("Recorded SPO2 intraday for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No SPO2 intraday records found for date %s to %s in Google mode", start_date_str, end_date_str)
+ 
+        # --- Weight and BMI (weight) ---
+        # Google field: weight → { weightGrams }. BMI is NOT exposed by the weight endpoint,
+        # so we fetch the latest height (data type "height" → heightMillimeters) and compute
+        # BMI = weight_kg / height_m^2.
+        # Deduplicates by timestamp — Withings via Health Connect produces duplicate entries
+        try:
+            points = get_google_datapoints_for_date_range("weight", start_date_str, end_date_str)
+        except requests.exceptions.HTTPError as e:
+            logging.error("Google Weight fetch failed: %s", str(e))
+            points = []
 
+        height_meters = None
+        try:
+            height_response = request_google_data_points_list("height", params={"pageSize": 100})
+            latest_mm, latest_time = None, None
+            for hp in height_response.get("dataPoints", []) if isinstance(height_response, dict) else []:
+                h = hp.get("height", {})
+                mm = extract_first_numeric(h.get("heightMillimeters"))
+                physical = (h.get("sampleTime") or {}).get("physicalTime")
+                if mm is not None and physical and (latest_time is None or physical > latest_time):
+                    latest_mm, latest_time = mm, physical
+            if latest_mm is not None:
+                height_meters = latest_mm / 1000.0
+                logging.info("Fetched latest height for BMI: %.3f m (recorded at %s)", height_meters, latest_time)
+        except Exception as e:
+            logging.warning("Google height fetch failed (BMI will be skipped): %s", str(e))
+
+        inserted_count = 0
+        seen_weight_timestamps = set()
+        for data_point, ts in points:
+            if ts in seen_weight_timestamps:
+                continue
+            seen_weight_timestamps.add(ts)
+            weight_fields = data_point.get("weight", {})
+            # API returns weightGrams, convert to kg
+            weight_grams = extract_first_numeric(weight_fields.get("weightGrams"))
+            weight_kg = weight_grams / 1000 if weight_grams is not None else None
+            # Store as pounds to match Fitbit API behaviour (dashboard converts lbs→kg)
+            weight_lbs = weight_kg * 2.205 if weight_kg is not None else None
+            bmi = round(weight_kg / (height_meters ** 2), 2) if (weight_kg is not None and height_meters) else None
+            if weight_lbs is not None:
+                collected_records.append({
+                    "measurement": "weight",
+                    "time": ts,
+                    "tags": {"Device": DEVICENAME},
+                    "fields": {
+                        "value": float(weight_lbs),      # pounds — matches existing Grafana dashboard
+                        "weightKg": float(weight_kg),     # kg — for future metric display
+                        "weightLbs": float(weight_lbs),   # explicit lbs field
+                    },
+                })
+                inserted_count += 1
+            if bmi is not None:
+                collected_records.append({
+                    "measurement": "bmi",
+                    "time": ts,
+                    "tags": {"Device": DEVICENAME},
+                    "fields": {"value": float(bmi)},
+                })
+                inserted_count += 1
+        if inserted_count:
+            logging.info("Recorded weight and BMI for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No Weight/BMI records found for date %s to %s in Google mode", start_date_str, end_date_str)
+ 
+        return  # ← Google path done, skip Fitbit code below
+ 
+    # --- Original Fitbit path (unchanged) ---
     hrv_data_list = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/hrv/date/{start_date_str}/{end_date_str}.json").get('hrv')
     if hrv_data_list != None:
         for data in hrv_data_list:
@@ -760,7 +989,7 @@ def get_daily_data_limit_30d(start_date_str, end_date_str):
         logging.info("Recorded HRV for date " + start_date_str + " to " + end_date_str)
     else:
         logging.error("Recording failed HRV for date " + start_date_str + " to " + end_date_str)
-
+ 
     try:
         br_response = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/br/date/{start_date_str}/{end_date_str}.json")
         br_data_list = br_response.get("br") if br_response else None
@@ -787,7 +1016,7 @@ def get_daily_data_limit_30d(start_date_str, end_date_str):
         logging.info("Recorded BR for date " + start_date_str + " to " + end_date_str)
     else:
         logging.warning("Records not found : BR for date " + start_date_str + " to " + end_date_str)
-
+ 
     skin_temp_data_list = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/temp/skin/date/{start_date_str}/{end_date_str}.json").get("tempSkin")
     if skin_temp_data_list != None:
         for temp_record in skin_temp_data_list:
@@ -806,7 +1035,7 @@ def get_daily_data_limit_30d(start_date_str, end_date_str):
         logging.info("Recorded Skin Temperature Variation for date " + start_date_str + " to " + end_date_str)
     else:
         logging.error("Recording failed : Skin Temperature Variation for date " + start_date_str + " to " + end_date_str)
-
+ 
     try:
         spo2_data_list = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/spo2/date/{start_date_str}/{end_date_str}/all.json")
     except requests.exceptions.HTTPError as e:
@@ -815,7 +1044,7 @@ def get_daily_data_limit_30d(start_date_str, end_date_str):
     if spo2_data_list != None:
         for days in spo2_data_list:
             data = days["minutes"]
-            for record in data: 
+            for record in data:
                 log_time = datetime.fromisoformat(record["minute"])
                 utc_time = LOCAL_TIMEZONE.localize(log_time).astimezone(pytz.utc).isoformat()
                 collected_records.append({
@@ -831,7 +1060,7 @@ def get_daily_data_limit_30d(start_date_str, end_date_str):
         logging.info("Recorded SPO2 intraday for date " + start_date_str + " to " + end_date_str)
     else:
         logging.error("Recording failed : SPO2 intraday for date " + start_date_str + " to " + end_date_str)
-
+ 
     weight_data_list = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/body/log/weight/date/{start_date_str}/{end_date_str}.json").get("weight")
     if weight_data_list != None:
         for entry in weight_data_list:
@@ -861,26 +1090,131 @@ def get_daily_data_limit_30d(start_date_str, end_date_str):
     else:
         logging.error("Recording failed : weight and BMI for date " + start_date_str + " to " + end_date_str)
 
-# Only for sleep data - limit 100 days - 1 query
-def get_daily_data_limit_100d(start_date_str, end_date_str):
-    if HEALTH_API_PROVIDER == "google":
-        logging.warning("Google mapping for sleep detail dataset is not finalized yet. Skipping this batch.")
-        return
 
+# Sleep data — limit 100 days
+def get_daily_data_limit_100d(start_date_str, end_date_str):
+    # Google sleep endpoint: data_type = "sleep", session record
+    # Google structure differs significantly from Fitbit API:
+    #   sleep.summary.minutesAsleep/minutesAwake/minutesInSleepPeriod/stagesSummary
+    #   sleep.stages[] → { startTime, endTime, type: AWAKE/LIGHT/DEEP/REM }
+    #   sleep.interval → { startTime, endTime }
+    # No efficiency field — computed as minutesAsleep/minutesInSleepPeriod * 100
+    # All minute values returned as strings, not ints
+    if HEALTH_API_PROVIDER == "google":
+        sleep_level_mapping = {'AWAKE': 3, 'REM': 2, 'LIGHT': 1, 'DEEP': 0, 'UNKNOWN': 4}
+        try:
+            points = get_google_datapoints_for_date_range("sleep", start_date_str, end_date_str)
+        except requests.exceptions.HTTPError as e:
+            logging.error("Google Sleep fetch failed: %s", str(e))
+            points = []
+        inserted_count = 0
+        for data_point, ts in points:
+            sleep = data_point.get("sleep", {})
+            if not sleep:
+                continue
+
+            summary = sleep.get("summary", {})
+            stages_summary = summary.get("stagesSummary", [])
+            stages_map = {s["type"]: int(s.get("minutes", 0)) for s in stages_summary}
+
+            minutes_asleep      = int(summary.get("minutesAsleep", 0))
+            minutes_awake       = int(summary.get("minutesAwake", 0))
+            minutes_in_period   = int(summary.get("minutesInSleepPeriod", 0))
+            minutes_after_wakeup = int(summary.get("minutesAfterWakeUp", 0))
+            minutes_to_fall     = int(summary.get("minutesToFallAsleep", 0))
+            minutes_light       = stages_map.get("LIGHT", 0)
+            minutes_rem         = stages_map.get("REM", 0)
+            minutes_deep        = stages_map.get("DEEP", 0)
+
+            # Compute efficiency: minutesAsleep / minutesInSleepPeriod * 100
+            efficiency = round(minutes_asleep / minutes_in_period * 100) if minutes_in_period > 0 else 0
+
+            is_main_sleep = sleep.get("metadata", {}).get("processed", True)
+
+            collected_records.append({
+                "measurement": "Sleep Summary",
+                "time": ts,
+                "tags": {"Device": DEVICENAME, "isMainSleep": is_main_sleep},
+                "fields": {
+                    "efficiency":            efficiency,
+                    "minutesAfterWakeup":    minutes_after_wakeup,
+                    "minutesAsleep":         minutes_asleep,
+                    "minutesToFallAsleep":   minutes_to_fall,
+                    "minutesInBed":          minutes_in_period,
+                    "minutesAwake":          minutes_awake,
+                    "minutesLight":          minutes_light,
+                    "minutesREM":            minutes_rem,
+                    "minutesDeep":           minutes_deep,
+                },
+            })
+            inserted_count += 1
+
+            # Sleep stage timeline from stages array
+            interval = sleep.get("interval", {})
+            for stage in sleep.get("stages", []):
+                stage_time_str = stage.get("startTime")
+                if not stage_time_str:
+                    continue
+                try:
+                    stage_dt = datetime.fromisoformat(stage_time_str.replace("Z", "+00:00"))
+                    stage_ts = stage_dt.astimezone(pytz.utc).isoformat()
+                except ValueError:
+                    continue
+                stage_type = stage.get("type", "UNKNOWN")
+                end_time_str = stage.get("endTime")
+                duration_secs = None
+                if end_time_str:
+                    try:
+                        end_dt = datetime.fromisoformat(end_time_str.replace("Z", "+00:00"))
+                        duration_secs = int((end_dt - stage_dt).total_seconds())
+                    except ValueError:
+                        pass
+                collected_records.append({
+                    "measurement": "Sleep Levels",
+                    "time": stage_ts,
+                    "tags": {"Device": DEVICENAME, "isMainSleep": is_main_sleep},
+                    "fields": {
+                        "level": sleep_level_mapping.get(stage_type, 4),
+                        "duration_seconds": duration_secs,
+                    },
+                })
+
+            # Wake marker at end of sleep session
+            end_time_str = interval.get("endTime")
+            if end_time_str:
+                try:
+                    wake_dt = datetime.fromisoformat(end_time_str.replace("Z", "+00:00"))
+                    wake_ts = wake_dt.astimezone(pytz.utc).isoformat()
+                    collected_records.append({
+                        "measurement": "Sleep Levels",
+                        "time": wake_ts,
+                        "tags": {"Device": DEVICENAME, "isMainSleep": is_main_sleep},
+                        "fields": {"level": sleep_level_mapping["AWAKE"], "duration_seconds": None},
+                    })
+                except ValueError:
+                    pass
+
+        if inserted_count:
+            logging.info("Recorded Sleep data for date %s to %s (Google mode): %s sessions", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No Sleep records found for date %s to %s in Google mode", start_date_str, end_date_str)
+        return
+ 
+    # --- Original Fitbit path (unchanged) ---
     sleep_data = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1.2/user/-/sleep/date/{start_date_str}/{end_date_str}.json").get("sleep")
     if sleep_data != None:
         for record in sleep_data:
             log_time = datetime.fromisoformat(record["startTime"])
             utc_time = LOCAL_TIMEZONE.localize(log_time).astimezone(pytz.utc).isoformat()
             try:
-                minutesLight= record['levels']['summary']['light']['minutes']
-                minutesREM = record['levels']['summary']['rem']['minutes']
-                minutesDeep = record['levels']['summary']['deep']['minutes']
+                minutesLight = record['levels']['summary']['light']['minutes']
+                minutesREM   = record['levels']['summary']['rem']['minutes']
+                minutesDeep  = record['levels']['summary']['deep']['minutes']
             except:
-                minutesLight= record['levels']['summary']['asleep']['minutes']
-                minutesREM = record['levels']['summary']['restless']['minutes']
-                minutesDeep = 0
-
+                minutesLight = record['levels']['summary']['asleep']['minutes']
+                minutesREM   = record['levels']['summary']['restless']['minutes']
+                minutesDeep  = 0
+ 
             collected_records.append({
                     "measurement":  "Sleep Summary",
                     "time": utc_time,
@@ -900,7 +1234,7 @@ def get_daily_data_limit_100d(start_date_str, end_date_str):
                         'minutesDeep': minutesDeep
                     }
                 })
-            
+ 
             sleep_level_mapping = {'wake': 3, 'rem': 2, 'light': 1, 'deep': 0, 'asleep': 1, 'restless': 2, 'awake': 3, 'unknown': 4}
             for sleep_stage in record['levels']['data']:
                 log_time = datetime.fromisoformat(sleep_stage["dateTime"])
@@ -934,13 +1268,228 @@ def get_daily_data_limit_100d(start_date_str, end_date_str):
         logging.info("Recorded Sleep data for date " + start_date_str + " to " + end_date_str)
     else:
         logging.error("Recording failed : Sleep data for date " + start_date_str + " to " + end_date_str)
-
-# Max date range 1 year, records HR zones, Activity minutes and Resting HR - 4 + 3 + 1 + 1 = 9 queries
+ 
+ 
+# Max date range 1 year — Resting HR, HR Zones, Activity Minutes, Steps/Calories/Distance
 def get_daily_data_limit_365d(start_date_str, end_date_str):
     if HEALTH_API_PROVIDER == "google":
-        logging.warning("Google mapping for long-range activity aggregates is not finalized yet. Skipping this batch.")
-        return
+ 
+        # --- Resting Heart Rate (daily-resting-heart-rate) ---
+        # Google field: dailyRestingHeartRate → { beatsPerMinute }
+        try:
+            points = get_google_datapoints_for_date_range("daily-resting-heart-rate", start_date_str, end_date_str)
+        except requests.exceptions.HTTPError as e:
+            logging.error("Google Resting HR fetch failed: %s", str(e))
+            points = []
+        inserted_count = 0
+        for data_point, ts in points:
+            rhr_fields = data_point.get("dailyRestingHeartRate", {})
+            bpm = extract_first_numeric(rhr_fields.get("beatsPerMinute"))
+            if bpm is None:
+                continue
+            collected_records.append({
+                "measurement": "RestingHR",
+                "time": ts,
+                "tags": {"Device": DEVICENAME},
+                "fields": {"value": float(bpm)},
+            })
+            inserted_count += 1
+        if inserted_count:
+            logging.info("Recorded Resting HR for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No Resting HR records found for date %s to %s in Google mode", start_date_str, end_date_str)
+ 
+        # --- HR Zones (active-zone-minutes dailyRollUp) ---
+        az_start = datetime.strptime(start_date_str, "%Y-%m-%d")
+        az_end   = datetime.strptime(end_date_str,   "%Y-%m-%d")
+        current  = az_start
+        inserted_count = 0
+        while current <= az_end:
+            payload = {
+                "range": {
+                    "start": {"date": {"year": current.year, "month": current.month, "day": current.day},
+                            "time": {"hours": 0, "minutes": 0, "seconds": 0, "nanos": 0}},
+                    "end":   {"date": {"year": current.year, "month": current.month, "day": current.day},
+                            "time": {"hours": 23, "minutes": 59, "seconds": 59, "nanos": 0}},
+                },
+                "windowSizeDays": 1,
+            }
+            try:
+                response = request_google_data_points_daily_rollup("active-zone-minutes", payload)
+                rollup_points = response.get("rollupDataPoints", []) if isinstance(response, dict) else []
+                for rp in rollup_points:
+                    azm = rp.get("activeZoneMinutes", {})
+                    fields = {
+                        "Normal":   0,  # Out of Range not tracked by this endpoint
+                        "Fat Burn": int(extract_first_numeric(azm.get("sumInFatBurnHeartZone")) or 0),
+                        "Cardio":   int(extract_first_numeric(azm.get("sumInCardioHeartZone"))  or 0),
+                        "Peak":     int(extract_first_numeric(azm.get("sumInPeakHeartZone"))    or 0),
+                    }
+                    if any(v > 0 for v in fields.values()):
+                        ts = LOCAL_TIMEZONE.localize(current).astimezone(pytz.utc).isoformat()
+                        collected_records.append({
+                            "measurement": "HR zones",
+                            "time": ts,
+                            "tags": {"Device": DEVICENAME},
+                            "fields": fields,
+                        })
+                        inserted_count += 1
+            except Exception as e:
+                logging.warning("Google active-zone-minutes rollup failed for %s: %s", current.strftime("%Y-%m-%d"), str(e))
+            current += timedelta(days=1)
+        if inserted_count:
+            logging.info("Recorded HR Zones for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No HR Zone records found for date %s to %s in Google mode", start_date_str, end_date_str)
+ 
+        # --- Activity Minutes via dailyRollUp (steps, total-calories, distance) ---
+        # These use the dailyRollUp POST endpoint for aggregated daily totals
+        rollup_map = [
+            # (data_type,        measurement_name,  field_name,   cast_fn)
+            ("steps",            "Total Steps",      "value",      float),
+            ("total-calories",   "calories",         "value",      float),
+        ]
+        
+        for data_type, measurement_name, field_name, cast_fn in rollup_map:
+            start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
+            end_date   = datetime.strptime(end_date_str,   "%Y-%m-%d")
+            current    = start_date
+            inserted_count = 0
+            while current <= end_date:
+                next_day = current + timedelta(days=1)
+                payload = {
+                    "range": {
+                        "start": {"date": {"year": current.year, "month": current.month, "day": current.day},
+                                  "time": {"hours": 0, "minutes": 0, "seconds": 0, "nanos": 0}},
+                        "end":   {"date": {"year": current.year, "month": current.month, "day": current.day},
+                                  "time": {"hours": 23, "minutes": 59, "seconds": 59, "nanos": 0}},
+                    },
+                    "windowSizeDays": 1,
+                }
+                try:
+                    response = request_google_data_points_daily_rollup(data_type, payload)
+                except Exception as e:
+                    logging.warning("Google dailyRollUp failed for %s on %s: %s", data_type, current.strftime("%Y-%m-%d"), str(e))
+                    current = next_day
+                    continue
+                rollup_points = response.get("rollupDataPoints", []) if isinstance(response, dict) else []
+                for rp in rollup_points:
+                    # Extract value using explicit field names to avoid picking up year from date objects
+                    value = None
+                    if data_type == "steps":
+                        value = extract_first_numeric(rp.get("steps", {}).get("countSum"))
+                    elif data_type == "total-calories":
+                        value = extract_first_numeric(rp.get("totalCalories", {}).get("kcalSum"))
+                    if value is None:
+                        continue
+                    # Timestamp: use civilStartTime from rollup point
+                    civil_start = rp.get("civilStartTime", {})
+                    date_val    = civil_start.get("date", {})
+                    try:
+                        dt = LOCAL_TIMEZONE.localize(datetime(
+                            int(date_val.get("year",  current.year)),
+                            int(date_val.get("month", current.month)),
+                            int(date_val.get("day",   current.day)),
+                        ))
+                        ts = dt.astimezone(pytz.utc).isoformat()
+                    except Exception:
+                        ts = LOCAL_TIMEZONE.localize(current).astimezone(pytz.utc).isoformat()
+                    collected_records.append({
+                        "measurement": measurement_name,
+                        "time": ts,
+                        "tags": {"Device": DEVICENAME},
+                        "fields": {field_name: cast_fn(value)},
+                    })
+                    inserted_count += 1
+                current = next_day
+            if inserted_count:
+                logging.info("Recorded %s for date %s to %s (Google mode): %s points", measurement_name, start_date_str, end_date_str, inserted_count)
+            else:
+                logging.warning("No %s records found for date %s to %s in Google mode", measurement_name, start_date_str, end_date_str)
+ 
+        # --- Distance (separate handling — nested under distance.millimetersSum) ---
+        dist_start = datetime.strptime(start_date_str, "%Y-%m-%d")
+        dist_end   = datetime.strptime(end_date_str,   "%Y-%m-%d")
+        current    = dist_start
+        inserted_count = 0
+        while current <= dist_end:
+            payload = {
+                "range": {
+                    "start": {"date": {"year": current.year, "month": current.month, "day": current.day},
+                              "time": {"hours": 0, "minutes": 0, "seconds": 0, "nanos": 0}},
+                    "end":   {"date": {"year": current.year, "month": current.month, "day": current.day},
+                              "time": {"hours": 23, "minutes": 59, "seconds": 59, "nanos": 0}},
+                },
+                "windowSizeDays": 1,
+            }
+            try:
+                dist_response = request_google_data_points_daily_rollup("distance", payload)
+                for rp in dist_response.get("rollupDataPoints", []) if isinstance(dist_response, dict) else []:
+                    mm = extract_first_numeric(rp.get("distance", {}).get("millimetersSum"))
+                    if mm is not None:
+                        ts = LOCAL_TIMEZONE.localize(current).astimezone(pytz.utc).isoformat()
+                        collected_records.append({
+                            "measurement": "distance",
+                            "time": ts,
+                            "tags": {"Device": DEVICENAME},
+                            "fields": {"value": float(mm / 1_000_000)},  # mm → km
+                        })
+                        inserted_count += 1
+            except Exception as e:
+                logging.warning("Google distance rollup failed for %s: %s", current.strftime("%Y-%m-%d"), str(e))
+            current += timedelta(days=1)
+        if inserted_count:
+            logging.info("Recorded distance for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No distance records found for date %s to %s in Google mode", start_date_str, end_date_str)
 
+        # --- Activity Minutes (sedentary-period, active-zone-minutes) ---
+        # Using active-zone-minutes for fairlyActive + veryActive approximation
+        # minutesSedentary via sedentary-period rollup
+        sedentary_start = datetime.strptime(start_date_str, "%Y-%m-%d")
+        sedentary_end   = datetime.strptime(end_date_str,   "%Y-%m-%d")
+        current = sedentary_start
+        inserted_count = 0
+        while current <= sedentary_end:
+            payload = {
+                "range": {
+                    "start": {"date": {"year": current.year, "month": current.month, "day": current.day},
+                              "time": {"hours": 0, "minutes": 0, "seconds": 0, "nanos": 0}},
+                    "end":   {"date": {"year": current.year, "month": current.month, "day": current.day},
+                              "time": {"hours": 23, "minutes": 59, "seconds": 59, "nanos": 0}},
+                },
+                "windowSizeDays": 1,
+            }
+            try:
+                sedentary_response = request_google_data_points_daily_rollup("sedentary-period", payload)
+                rollup_points = sedentary_response.get("rollupDataPoints", []) if isinstance(sedentary_response, dict) else []
+                total_sedentary_minutes = 0
+                for rp in rollup_points:
+                    sedentary_data = rp.get("sedentaryPeriod", {})
+                    duration = sedentary_data.get("durationSum") or sedentary_data.get("durationSeconds") or sedentary_data.get("duration")
+                    secs = convert_google_duration_to_seconds(duration)
+                    if secs is not None:
+                        total_sedentary_minutes += secs / 60
+                if total_sedentary_minutes > 0:
+                    ts = LOCAL_TIMEZONE.localize(current).astimezone(pytz.utc).isoformat()
+                    collected_records.append({
+                        "measurement": "Activity Minutes",
+                        "time": ts,
+                        "tags": {"Device": DEVICENAME},
+                        "fields": {"minutesSedentary": int(total_sedentary_minutes)},
+                    })
+                    inserted_count += 1
+            except Exception as e:
+                logging.warning("Google sedentary-period rollup failed for %s: %s", current.strftime("%Y-%m-%d"), str(e))
+            current += timedelta(days=1)
+        if inserted_count:
+            logging.info("Recorded Activity Minutes (sedentary) for date %s to %s (Google mode): %s points", start_date_str, end_date_str, inserted_count)
+        else:
+            logging.warning("No sedentary period records found for date %s to %s in Google mode", start_date_str, end_date_str)
+ 
+        return  # ← Google path done
+ 
+    # --- Original Fitbit path (unchanged) ---
     activity_minutes_list = ["minutesSedentary", "minutesLightlyActive", "minutesFairlyActive", "minutesVeryActive"]
     for activity_type in activity_minutes_list:
         activity_minutes_data_list = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/activities/tracker/{activity_type}/date/{start_date_str}/{end_date_str}.json").get("activities-tracker-"+activity_type)
@@ -961,8 +1510,7 @@ def get_daily_data_limit_365d(start_date_str, end_date_str):
             logging.info("Recorded " + activity_type + "for date " + start_date_str + " to " + end_date_str)
         else:
             logging.error("Recording failed : " + activity_type + " for date " + start_date_str + " to " + end_date_str)
-        
-
+ 
     activity_others_list = ["distance", "calories", "steps"]
     for activity_type in activity_others_list:
         activity_others_data_list = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/activities/tracker/{activity_type}/date/{start_date_str}/{end_date_str}.json").get("activities-tracker-"+activity_type)
@@ -984,8 +1532,7 @@ def get_daily_data_limit_365d(start_date_str, end_date_str):
             logging.info("Recorded " + activity_name + " for date " + start_date_str + " to " + end_date_str)
         else:
             logging.error("Recording failed : " + activity_name + " for date " + start_date_str + " to " + end_date_str)
-        
-
+ 
     HR_zones_data_list = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/activities/heart/date/{start_date_str}/{end_date_str}.json").get("activities-heart")
     if HR_zones_data_list != None:
         for data in HR_zones_data_list:
@@ -997,7 +1544,6 @@ def get_daily_data_limit_365d(start_date_str, end_date_str):
                     "tags": {
                         "Device": DEVICENAME
                     },
-                    # Using get() method with a default value 0 to prevent keyerror ( see issue #31)
                     "fields": {
                         "Normal" : data["value"]["heartRateZones"][0].get("minutes", 0),
                         "Fat Burn" :  data["value"]["heartRateZones"][1].get("minutes", 0),
@@ -1019,7 +1565,7 @@ def get_daily_data_limit_365d(start_date_str, end_date_str):
         logging.info("Recorded RHR and HR zones for date " + start_date_str + " to " + end_date_str)
     else:
         logging.error("Recording failed : RHR and HR zones for date " + start_date_str + " to " + end_date_str)
-
+ 
     HR_zone_minutes_list = request_data_from_fitbit(f"{FITBIT_API_BASE_URL}/1/user/-/activities/active-zone-minutes/date/{start_date_str}/{end_date_str}.json").get("activities-active-zone-minutes")
     if HR_zone_minutes_list != None:
         for data in HR_zone_minutes_list:
@@ -1037,6 +1583,7 @@ def get_daily_data_limit_365d(start_date_str, end_date_str):
         logging.info("Recorded HR zone minutes for date " + start_date_str + " to " + end_date_str)
     else:
         logging.error("Recording failed : HR zone minutes for date " + start_date_str + " to " + end_date_str)
+ 
 
 # records SPO2 single days for the whole given period - 1 query
 def get_daily_data_limit_none(start_date_str, end_date_str):
@@ -1166,11 +1713,22 @@ def get_tcx_data(tcx_url, ActivityID):
 # Fetches latest activities from record ( upto last 50 )
 def fetch_latest_activities(end_date_str):
     if HEALTH_API_PROVIDER == "google":
+        # The exercise endpoint returns the most recent records first. We pull the unfiltered
+        # latest page (capped at ~50 like the Fitbit list endpoint) instead of trying to filter
+        # by date — Google rejects most member-level filters on `exercise` and a same-day filter
+        # would miss the 50-most-recent-activities semantics of the original Fitbit call.
         try:
-            points = get_google_datapoints_for_date("exercise", end_date_str, page_size=25)
+            response = request_google_data_points_list("exercise", params={"pageSize": 100})
         except requests.exceptions.HTTPError as err:
-            logging.error("Google exercise fetch failed for %s: %s", end_date_str, str(err))
-            points = []
+            logging.error("Google exercise fetch failed: %s", str(err))
+            response = None
+
+        raw_points = response.get("dataPoints", []) if isinstance(response, dict) else []
+        points = []
+        for dp in raw_points[:50]:
+            ts = parse_google_datapoint_timestamp(dp, "exercise")
+            if ts:
+                points.append((dp, ts))
 
         inserted_count = 0
         for data_point, ts in points:
@@ -1209,7 +1767,7 @@ def fetch_latest_activities(end_date_str):
                 "fields": fields
             })
             inserted_count += 1
-        logging.info("Fetched recent exercises for date %s (Google mode): %s points", end_date_str, inserted_count)
+        logging.info("Fetched recent exercises (Google mode): %s points", inserted_count)
         return
 
     next_end_date_str = (datetime.strptime(end_date_str, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
@@ -1341,7 +1899,3 @@ if SCHEDULE_AUTO_UPDATE:
             collected_records = []
         time.sleep(30)
         update_working_dates()
-        
-
-
-

--- a/Grafana_Dashboard/Health Stats Dashboard for influxdb-v1.json
+++ b/Grafana_Dashboard/Health Stats Dashboard for influxdb-v1.json
@@ -1914,7 +1914,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "last"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -4134,7 +4134,7 @@
       "pluginVersion": "11.6.0",
       "targets": [
         {
-          "alias": "Light Activity",
+          "alias": "Fat Burn (AZM)",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_HEALTH_STATS}"
@@ -4153,8 +4153,48 @@
               "type": "fill"
             }
           ],
-          "hide": false,
-          "measurement": "Activity Minutes",
+          "measurement": "HR zones",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Fat Burn"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Cardio (AZM)",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_HEALTH_STATS}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "HR zones",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "B",
@@ -4163,63 +4203,20 @@
             [
               {
                 "params": [
-                  "minutesLightlyActive"
+                  "Cardio"
                 ],
                 "type": "field"
               },
               {
                 "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [],
-          "tz": "$TimeZone"
-        },
-        {
-          "alias": "Fair Activity",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_HEALTH_STATS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "Activity Minutes",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "queryType": "randomWalk",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "minutesFairlyActive"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
+                "type": "max"
               }
             ]
           ],
           "tags": []
         },
         {
-          "alias": "Intense Activity",
+          "alias": "Peak (AZM)",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_HEALTH_STATS}"
@@ -4238,8 +4235,7 @@
               "type": "fill"
             }
           ],
-          "hide": false,
-          "measurement": "Activity Minutes",
+          "measurement": "HR zones",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "C",
@@ -4248,13 +4244,54 @@
             [
               {
                 "params": [
-                  "minutesVeryActive"
+                  "Peak"
                 ],
                 "type": "field"
               },
               {
                 "params": [],
-                "type": "distinct"
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Sedentary",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_HEALTH_STATS}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "Activity Minutes",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "minutesSedentary"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
               }
             ]
           ],
@@ -5539,14 +5576,52 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Time"
+              "options": "duration"
             },
             "properties": [
               {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text"
-                }
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "distance"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "lengthm"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AverageHeartRate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "displayName",
+                "value": "Avg HR"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "calories"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
               }
             ]
           }
@@ -5582,7 +5657,6 @@
       "pluginVersion": "11.6.0",
       "targets": [
         {
-          "alias": "Walk",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_HEALTH_STATS}"
@@ -5591,10 +5665,10 @@
           "measurement": "Activity Records",
           "orderByTime": "DESC",
           "policy": "default",
-          "query": "SELECT \"duration\" FROM \"Activity Records\" WHERE (\"ActivityName\" = 'Walk') AND $timeFilter ORDER BY time DESC",
+          "query": "SELECT \"ActivityName\", \"duration\", \"calories\", \"AverageHeartRate\", \"distance\", \"steps\" FROM \"Activity Records\" WHERE $timeFilter ORDER BY time DESC",
           "rawQuery": true,
           "refId": "A",
-          "resultFormat": "time_series",
+          "resultFormat": "table",
           "select": [
             [
               {
@@ -5605,79 +5679,7 @@
               }
             ]
           ],
-          "tags": [
-            {
-              "key": "ActivityName",
-              "operator": "=",
-              "value": "Walk"
-            }
-          ]
-        },
-        {
-          "alias": "Swimming",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_HEALTH_STATS}"
-          },
-          "groupBy": [],
-          "hide": false,
-          "measurement": "Activity Records",
-          "orderByTime": "DESC",
-          "policy": "default",
-          "query": "SELECT \"calories\" FROM \"Activity Records\" WHERE (\"ActivityName\" = 'Walk') ",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "duration"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "ActivityName",
-              "operator": "=",
-              "value": "Swim"
-            }
-          ]
-        },
-        {
-          "alias": "Biking",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_HEALTH_STATS}"
-          },
-          "groupBy": [],
-          "hide": false,
-          "measurement": "Activity Records",
-          "orderByTime": "DESC",
-          "policy": "default",
-          "query": "SELECT \"calories\" FROM \"Activity Records\" WHERE (\"ActivityName\" = 'Walk') ",
-          "rawQuery": false,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "duration"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "ActivityName",
-              "operator": "=",
-              "value": "Outdoor Bike"
-            }
-          ]
+          "tags": []
         }
       ],
       "timeFrom": "1w",

--- a/migrate_sleep_anchor.py
+++ b/migrate_sleep_anchor.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+One-off migration: re-anchor existing "Sleep Summary" timestamps in InfluxDB.
+
+For each row, the new timestamp is 12:00 UTC of the "sleep date" — the day the
+user conceptually went to bed in their local timezone. If the original local
+start time is before noon, the session belongs to the previous local day.
+
+Sleep Levels stage rows are NOT migrated: they hold real stage timestamps used
+for the hypnogram timeline.
+
+Run inside the fitbit-fetch-data container so influxdb-python is available:
+
+  docker compose run --rm \
+    -e DRY_RUN=True -e LOCAL_TIMEZONE=Europe/Paris \
+    -v "$PWD/migrate_sleep_anchor.py:/app/migrate_sleep_anchor.py" \
+    --entrypoint python fitbit-fetch-data /app/migrate_sleep_anchor.py
+"""
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytz
+from influxdb import InfluxDBClient
+
+INFLUXDB_HOST = os.environ.get("INFLUXDB_HOST", "influxdb")
+INFLUXDB_PORT = int(os.environ.get("INFLUXDB_PORT", "8086"))
+INFLUXDB_USERNAME = os.environ["INFLUXDB_USERNAME"]
+INFLUXDB_PASSWORD = os.environ["INFLUXDB_PASSWORD"]
+INFLUXDB_DATABASE = os.environ.get("INFLUXDB_DATABASE", "FitbitHealthStats")
+LOCAL_TIMEZONE = pytz.timezone(os.environ.get("LOCAL_TIMEZONE", "Europe/Paris"))
+DRY_RUN = os.environ.get("DRY_RUN", "False").strip().lower() in ("true", "1", "yes", "y")
+
+INT_FIELDS = (
+    "efficiency", "minutesAfterWakeup", "minutesAsleep", "minutesToFallAsleep",
+    "minutesInBed", "minutesAwake", "minutesLight", "minutesREM", "minutesDeep",
+)
+
+
+def anchor(start_dt_utc, local_tz):
+    local_dt = start_dt_utc.astimezone(local_tz)
+    sleep_date = local_dt.date() - timedelta(days=1) if local_dt.hour < 12 else local_dt.date()
+    return datetime(sleep_date.year, sleep_date.month, sleep_date.day, 12, 0, 0, tzinfo=pytz.utc)
+
+
+def main():
+    client = InfluxDBClient(
+        host=INFLUXDB_HOST, port=INFLUXDB_PORT,
+        username=INFLUXDB_USERNAME, password=INFLUXDB_PASSWORD,
+        database=INFLUXDB_DATABASE,
+    )
+    rows = list(client.query('SELECT * FROM "Sleep Summary"', epoch="ns").get_points())
+    print(f"Found {len(rows)} Sleep Summary rows")
+
+    migrate = []
+    unchanged = 0
+    for r in rows:
+        old_dt = datetime.fromtimestamp(int(r["time"]) / 1e9, tz=pytz.utc)
+        new_dt = anchor(old_dt, LOCAL_TIMEZONE)
+        if old_dt == new_dt:
+            unchanged += 1
+            continue
+        migrate.append((r, old_dt, new_dt))
+
+    # Detect collisions: multiple sleeps anchoring to the same sleep_date
+    by_target = {}
+    for r, old, new in migrate:
+        by_target.setdefault(new.isoformat(), []).append(old.isoformat())
+    collisions = {k: v for k, v in by_target.items() if len(v) > 1}
+
+    print(f"  to migrate: {len(migrate)}")
+    print(f"  unchanged : {unchanged}")
+    print(f"  collisions: {len(collisions)} target dates with >1 source row")
+
+    if collisions:
+        print("  sample collisions (last write wins after migration):")
+        for k, v in list(collisions.items())[:5]:
+            print(f"    {k} <- {v}")
+
+    if migrate:
+        print("  sample migrations:")
+        for r, old, new in migrate[:5]:
+            print(f"    {old.isoformat()}  ->  {new.isoformat()}   eff={r.get('efficiency')}  asleep={r.get('minutesAsleep')}")
+
+    if DRY_RUN:
+        print("\nDRY_RUN=True — no writes. Re-run with DRY_RUN=False to apply.")
+        return
+
+    # Group migrations by target sleep_date so that collisions (multiple sessions
+    # mapping to the same noon-UTC anchor) get sub-second offsets — preserves all
+    # data and makes the longest sleep "win" for `last`/`lastNotNull` reducers.
+    from collections import defaultdict
+    groups = defaultdict(list)
+    for r, old, new in migrate:
+        groups[new.date()].append((r, old, new))
+
+    points = []
+    delete_ts_ns = []
+    for sleep_date, items in groups.items():
+        items.sort(key=lambda x: int(x[0].get("minutesAsleep") or 0))  # shortest first, longest last
+        for offset_idx, (r, old, new) in enumerate(items):
+            new_ts = new + timedelta(seconds=offset_idx)
+            fields = {}
+            for k, v in r.items():
+                if k in ("time", "Device", "isMainSleep"):
+                    continue
+                if v is None:
+                    continue
+                if k in INT_FIELDS:
+                    fields[k] = int(v)
+                else:
+                    fields[k] = v
+            tags = {
+                "Device": r.get("Device") or "Versa4",
+                "isMainSleep": str(r.get("isMainSleep", "True")),
+            }
+            points.append({
+                "measurement": "Sleep Summary",
+                "time": new_ts.isoformat(),
+                "tags": tags,
+                "fields": fields,
+            })
+            delete_ts_ns.append(int(old.timestamp() * 1e9))
+
+    print(f"\nWriting {len(points)} new points...")
+    # Batch writes
+    BATCH = 500
+    for i in range(0, len(points), BATCH):
+        client.write_points(points[i:i + BATCH], time_precision="n")
+    print("Written.")
+
+    print(f"Deleting {len(delete_ts_ns)} old points...")
+    # Group deletes by time to avoid pounding the API
+    for i, ts_ns in enumerate(delete_ts_ns):
+        client.query(f'DELETE FROM "Sleep Summary" WHERE time = {ts_ns}')
+        if (i + 1) % 100 == 0:
+            print(f"  {i + 1}/{len(delete_ts_ns)} deleted")
+    print("Deleted.")
+
+    final = list(client.query('SELECT COUNT(efficiency) FROM "Sleep Summary"').get_points())
+    print(f"Final Sleep Summary row count: {final[0]['count'] if final else 'unknown'}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyError as e:
+        sys.exit(f"Missing env var: {e}")


### PR DESCRIPTION
# Google Health API: full data-type mapping + paginated intraday fetch

This PR fleshes out `HEALTH_API_PROVIDER=google` mode so that every data type
that previously raised `"not finalized yet"` warnings now writes to InfluxDB,
and fixes an intraday pagination bug that silently dropped most of each day's
heart-rate samples.

All Fitbit code paths are untouched — every `if HEALTH_API_PROVIDER == "google"`
block returns early. Fitbit users see no change.

Tested end-to-end on a Fitbit Versa 4 with InfluxDB v1 + the bundled Grafana
dashboard.

## Python changes (`Fitbit_Fetch.py`)

### Pagination (the silent data-loss bug)

`get_google_datapoints_for_date` used to make a single `dataPoints` list call
with `pageSize=10000` and ignored `nextPageToken`. Google caps responses at
~5000 points per page, so a full day of heart-rate data (~30k samples) was
truncated to its last ~4 hours.

Now the function loops on `nextPageToken` (capped at 50 pages for safety) and
gracefully degrades if pagination fails mid-stream.

### New data-type mappings

| Data type           | Google endpoint                          | Notes |
|---------------------|------------------------------------------|-------|
| HRV                 | `daily-heart-rate-variability`           | `averageHeartRateVariabilityMilliseconds`, `deepSleepRootMeanSquareOfSuccessiveDifferencesMilliseconds` |
| Breathing Rate      | `daily-respiratory-rate`                 | `breathsPerMinute` (not `value`) |
| Skin Temperature    | `daily-sleep-temperature-derivations`    | Stored as delta = nightly − baseline |
| SPO2 (intraday)     | `oxygen-saturation`                      | per-sample `percentage` |
| Resting HR          | `daily-resting-heart-rate`               | `beatsPerMinute` (string, not `bpm`) |
| HR Zones            | `active-zone-minutes` (dailyRollUp)      | Fat Burn / Cardio / Peak; `daily-heart-rate-zones` only exposes thresholds, not minutes |
| Total Steps         | `steps` (dailyRollUp)                    | `countSum` |
| Calories            | `total-calories` (dailyRollUp)           | `kcalSum` |
| Distance            | `distance` (dailyRollUp)                 | `millimetersSum` / 1,000,000 → km |
| Sedentary Minutes   | `sedentary-period` (dailyRollUp)         | `durationSum` like `"38340s"` |
| Sleep Summary       | `sleep`                                  | Rewritten — Google structure differs from Fitbit (`summary.minutesAsleep`, `stagesSummary[]`, no `efficiency` field) |
| Sleep Levels        | `sleep`                                  | Stages as `AWAKE`/`LIGHT`/`DEEP`/`REM` from `sleep.stages[]` |
| Weight              | `weight`                                 | `weightGrams` → lbs to match Fitbit dashboard (also stores `weightKg`, `weightLbs`). Deduped by timestamp (Withings via Health Connect double-reports). |
| BMI                 | `height` + `weight`                      | Google `weight` has no BMI field; compute as `weight_kg / height_m²` using latest `height.heightMillimeters`. |
| Activities          | `exercise`                               | No date filter — endpoint sorts by recency; pull last 50 like Fitbit's `activities/list.json`. |

### Gotcha codified in the patch

The recursive `extract_first_numeric()` helper picks the first numeric value in
a nested structure. Google API responses contain date objects like
`{"year": 2026, "month": 5, "day": 8}`, so calling
`extract_first_numeric(rhr_fields)` on the whole payload returned `2026` instead
of the heart rate. **Always extract by explicit field name** —
`extract_first_numeric(rhr_fields.get("beatsPerMinute"))`. This bug was the
root cause of Resting HR, Breathing Rate, and Distance all showing `2026` in
Grafana.

### Known remaining gaps

- **Battery level** — Fitbit `/devices.json` has no Google equivalent.
- **HRV pre-2022** — older Fitbit hardware didn't track HRV.
- **Light/Fairly/Very active minutes** — Google's API only exposes Sedentary
  via `sedentary-period` and Fat Burn/Cardio/Peak via `active-zone-minutes`.
  The dashboard's Activity panel is repointed accordingly (see below).
- **`civil_start_time` filter on `sleep`** — Google returns HTTP 400; fallback
  to `civil_end_time` works.

## Dashboard changes (`Health Stats Dashboard for influxdb-v1.json`)

Three changes, two of which are independent of Google mode.

### `Last Day Total Sleep` (id 50) — bug fix, applies to both providers

The gauge's reducer was `last`. With `GROUP BY time(1d) fill(null)`, the "last"
bucket is *today* — empty until tonight's sleep is fetched, so the gauge
displays blank for most of the day. Switched to `lastNotNull` so it shows the
most recent night's sleep regardless of whether today's bucket exists yet.

### `Activity` panel (id 13) — Google mode adaptation

The original three queries (`minutesLightlyActive`, `minutesFairlyActive`,
`minutesVeryActive`) have no Google equivalent. Repointed to Fat Burn / Cardio
/ Peak from the `HR zones` measurement plus Sedentary from `Activity Minutes`
— this is what `active-zone-minutes` + `sedentary-period` actually expose.
Fitbit users will see the same data sourced from the existing AZM endpoint.

### `Recent Activity` panel (id 34) — robustness

The original had three hardcoded `ActivityName` filters (Walk, Swim, Outdoor
Bike). Replaced with a single flat-table query that auto-discovers every
activity name in the database — new activity types appear without dashboard
edits. Existing Walk/Swim/Bike rows still appear.

## Test commands

```bash
# Dry run for a single day
docker compose run --rm \
  -e DRY_RUN_MODE=True \
  -e AUTO_DATE_RANGE=False \
  -e MANUAL_START_DATE=2026-05-12 \
  -e MANUAL_END_DATE=2026-05-12 \
  fitbit-fetch-data

# Spot-check ingested data
docker exec influxdb influx -database FitbitHealthStats -execute \
  'SELECT * FROM "Sleep Summary" LIMIT 3'
```
