### PR TITLE
feat(google): auto-detect DEVICENAME from Google Health API device metadata

### DIFF
--- a/Fitbit_Fetch.py
+++ b/Fitbit_Fetch.py
@@ -618,10 +618,41 @@ def get_user_timezone_name():
     return "UTC"
 
 
+def discover_google_device_name():
+    """Inspect a few popular data types and return the first dataSource.device.displayName
+    we can find (e.g. "Versa 4"). Google attaches device metadata to every data point even
+    though it does not expose battery telemetry. Returns None if nothing usable is found."""
+    for data_type in ("heart-rate", "steps", "daily-resting-heart-rate", "weight", "exercise"):
+        try:
+            resp = request_google_data_points_list(
+                data_type, params={"pageSize": 1}, suppress_http_error_log=True
+            )
+        except requests.exceptions.HTTPError:
+            continue
+        if not isinstance(resp, dict):
+            continue
+        for dp in resp.get("dataPoints", []):
+            device = (dp.get("dataSource") or {}).get("device") or {}
+            name = device.get("displayName")
+            if name:
+                return name.strip()
+    return None
+
+
 if LOCAL_TIMEZONE == "Automatic":
     LOCAL_TIMEZONE = pytz.timezone(get_user_timezone_name())
 else:
     LOCAL_TIMEZONE = pytz.timezone(LOCAL_TIMEZONE)
+
+# Auto-detect the device name from the Google Health API if the user did not set
+# DEVICENAME explicitly. Falls back silently to the placeholder if discovery fails.
+if HEALTH_API_PROVIDER == "google" and DEVICENAME == "Your_Device_Name":
+    discovered_device_name = discover_google_device_name()
+    if discovered_device_name:
+        logging.info("Auto-detected Google device displayName: %s (override with DEVICENAME env var)", discovered_device_name)
+        DEVICENAME = discovered_device_name
+    else:
+        logging.info("Could not auto-detect device displayName from Google Health API; keeping default '%s'", DEVICENAME)
 
 # %% [markdown]
 # ## Selecting Dates for update


### PR DESCRIPTION
## Problem

Users running `HEALTH_API_PROVIDER=google` who don't set the `DEVICENAME` env var 
get `"Your_Device_Name"` written as the InfluxDB tag on every data point, making 
device-filtered queries useless.

## Fix

If `DEVICENAME` is not set (or is the default placeholder), the fetcher now reads 
the `displayName` from the first available Google Health API data point and uses 
that as the tag value automatically.

The explicit `DEVICENAME` env var still takes priority, so users with multiple 
devices or a preferred tag name are unaffected.

## Testing

Tested with `DEVICENAME` unset — auto-detection log confirmed:

slammy@slammyhomelab:/tmp/fitbit-grafana-pr$ docker compose -f ~/HomeLab/fitbit-grafana/docker-compose.yml run --rm \
>   -e DEVICENAME="" \
>   -e BULK_UPDATE_MODE=True \
>   -e AUTO_DATE_RANGE=False \
>   -e MANUAL_START_DATE=2026-05-07 \
>   -e MANUAL_END_DATE=2026-05-07 \
>   fitbit-fetch-data 2>&1 | grep -E "(DEVICENAME|device|Device|INFO)" | grep -v "DEBUG\|HTTP\|influxdb\|token"
2026-05-14 08:59:47,272 - INFO - Auto-detected Google device displayName: Versa 4 (override with DEVICENAME env var)


## Files changed

- `Fitbit_Fetch.py` only

> Developed with AI assistance (Claude), manually tested on real device data.