### PR TITLE
fix(sleep): anchor Sleep Summary to the user's bedtime day, not session start

### DIFF
--- a/Fitbit_Fetch.py
+++ b/Fitbit_Fetch.py
@@ -892,7 +892,19 @@ def get_daily_data_limit_30d(start_date_str, end_date_str):
     else:
         logging.error("Recording failed : weight and BMI for date " + start_date_str + " to " + end_date_str)
 
-# Only for sleep data - limit 100 days - 1 query
+# Anchor a sleep session to the day the user conceptually went to bed, so it buckets
+# correctly in Grafana regardless of how late they fell asleep or which timezone the
+# dashboard is viewed in. Rule: if start time in local TZ is < noon (post-midnight
+# sleep), the session belongs to the previous local day; otherwise the local day.
+# Returns ISO at 12:00 UTC of that sleep date — stable for any viewer TZ within ±12h.
+def compute_sleep_date_anchor_ts(start_dt, local_tz):
+    if start_dt.tzinfo is None:
+        start_dt = local_tz.localize(start_dt)
+    local_dt = start_dt.astimezone(local_tz)
+    sleep_date = local_dt.date() - timedelta(days=1) if local_dt.hour < 12 else local_dt.date()
+    return datetime(sleep_date.year, sleep_date.month, sleep_date.day, 12, 0, 0, tzinfo=pytz.utc).isoformat()
+
+# Sleep data — limit 100 days
 def get_daily_data_limit_100d(start_date_str, end_date_str):
     if HEALTH_API_PROVIDER == "google":
         logging.warning("Google mapping for sleep detail dataset is not finalized yet. Skipping this batch.")
@@ -902,19 +914,19 @@ def get_daily_data_limit_100d(start_date_str, end_date_str):
     if sleep_data != None:
         for record in sleep_data:
             log_time = datetime.fromisoformat(record["startTime"])
-            utc_time = LOCAL_TIMEZONE.localize(log_time).astimezone(pytz.utc).isoformat()
+            summary_time = compute_sleep_date_anchor_ts(log_time, LOCAL_TIMEZONE)
             try:
                 minutesLight= record['levels']['summary']['light']['minutes']
                 minutesREM = record['levels']['summary']['rem']['minutes']
                 minutesDeep = record['levels']['summary']['deep']['minutes']
             except:
-                minutesLight= record['levels']['summary']['asleep']['minutes']
-                minutesREM = record['levels']['summary']['restless']['minutes']
-                minutesDeep = 0
+                minutesLight = record['levels']['summary']['asleep']['minutes']
+                minutesREM   = record['levels']['summary']['restless']['minutes']
+                minutesDeep  = 0
 
             collected_records.append({
                     "measurement":  "Sleep Summary",
-                    "time": utc_time,
+                    "time": summary_time,
                     "tags": {
                         "Device": DEVICENAME,
                         "isMainSleep": record["isMainSleep"],


### PR DESCRIPTION
## Problem

Sleep sessions that start after midnight (e.g. fall asleep at 00:30 local time) 
are attributed to the day they technically started rather than the day the user 
went to bed. This causes a gap on the previous day in Grafana dashboards.

Multi-timezone users also see day attribution shift when toggling the dashboard 
timezone.

## Fix

Added a `compute_sleep_date_anchor_ts()` helper that determines the correct 
"sleep date" from the local-time hour: if the session starts before noon local 
time, it belongs to the previous local day (post-midnight sleep). The Sleep 
Summary row is anchored at 12:00 UTC of that sleep date, which buckets correctly 
in any Grafana viewer timezone within ±12h of UTC.

Sleep Levels stage rows keep their real UTC timestamps — they form a continuous 
hypnogram timeline, not a daily aggregation.

## Tests
2nd of May I want to bed at 2 in the morning

slammy@slammyhomelab:/tmp/fitbit-grafana-pr$ docker exec influxdb influx -database FitbitHealthStats -execute  "SELECT * FROM \"Sleep Levels\" WHERE time >= '2026-05-02T00:00:00Z' AND time <= '2026-05-02T12:00:00Z' ORDER BY time ASC LIMIT 5" -precision rfc3339

name: Sleep Levels
time                 Device duration_seconds isMainSleep level
----                 ------ ---------------- ----------- -----
2026-05-02T00:09:30Z Versa4 5580             True        1
2026-05-02T01:42:30Z Versa4 2310             True        2
2026-05-02T02:21:00Z Versa4 210              True        1
2026-05-02T02:24:30Z Versa4 540              True        2
2026-05-02T02:33:30Z Versa4 3240             True        1


slammy@slammyhomelab:/tmp/fitbit-grafana-pr$ docker exec influxdb influx -database FitbitHealthStats -execute   "SELECT * FROM \"Sleep Summary\" WHERE time >= '2026-05-01T12:00:00Z' AND time <= '2026-05-03T12:00:00Z'" -precision rfc3339

name: Sleep Summary
time                 Device efficiency isMainSleep minutesAfterWakeup minutesAsleep minutesAwake minutesDeep minutesInBed minutesLight minutesREM minutesToFallAsleep
----                 ------ ---------- ----------- ------------------ ------------- ------------ ----------- ------------ ------------ ---------- -------------------
2026-05-01T12:00:00Z Versa4 99         True        0                  523           6            78          529          292          153        0
2026-05-02T12:00:00Z Versa4 96         True        0                  365           14           55          379          230          80         0
2026-05-03T12:00:00Z Versa4 99         True        0                  500           7            112         507          275          113        0

The fix attached that session to the 2nd of may, not the 1st

Hence a graph that shows sleep sessions everyday

<img width="1794" height="263" alt="Screenshot 2026-05-14 115046" src="https://github.com/user-attachments/assets/7d46aa0d-f85d-4324-8f75-ddc664457c1a" />


## Scope

- Fitbit code path only in this PR
- Google provider sleep anchor will follow in a separate PR once the full Google 
  Sleep mapping (currently in review in #67  is merged

## Files changed

- `Fitbit_Fetch.py` only

> Developed with AI assistance (Claude), manually tested on real device data.