### PR TITLE
Fix Google Health OAuth client setup instructions

### DIFF
--- a/extra/google-migration.md
+++ b/extra/google-migration.md
@@ -46,16 +46,26 @@ Google uses URL scopes. Use only what you need. Typical read-only scopes for thi
 1. Open Google Cloud Console:
    - https://console.cloud.google.com
 2. Create or select a project.
-3. Enable **Google Health API** for the project from services.
-4. Configure OAuth consent screen:
-   - Set app information
-   - Add required test users who can use the app (add yourself) if app is in Testing mode (from the Audience tab of sidebar) or make the app public. Otherwise you will get an access denied error.
+3. Enable **Google Health API** for the project:
+   - Go to **APIs & Services** -> **Library**
+   - Search for **Google Health API**
+   - Open it and click **Enable**
+4. Configure the OAuth consent screen:
+   - Go to **Google Auth Platform**
+   - Configure the app information under **Branding**
+   - Add the required Google Health API scopes under **Data Access**, if prompted
+   - If the app is in **Testing** mode, add all users who need access under **Audience** -> **Test users**.
+     Make sure to add yourself. Otherwise, the OAuth flow can fail with an access denied error.
 5. Create OAuth credentials:
-   - APIs & Services -> Credentials -> Create Credentials -> OAuth client ID
-   - Application type: Desktop app
-6. Add redirect URI exactly:
-   - `http://localhost:8080`
-7. Save and copy:
+   - Go to **Google Auth Platform** -> **Clients**
+   - Click **Create client**
+   - Application type: **Web application**
+   - Choose a descriptive name, for example `Google Health Local OAuth Client`
+6. Add the redirect URI:
+   - Under **Authorized redirect URIs**, click **Add URI**
+   - Add exactly:
+     - `http://localhost:8080`
+7. Save the client and copy:
    - `GOOGLE_CLIENT_ID`
    - `GOOGLE_CLIENT_SECRET`
 


### PR DESCRIPTION
## Summary

This PR updates the Google Cloud OAuth setup instructions for the Google Health API migration guide.

The previous instructions told users to create an OAuth client with application type **Desktop app**, but then asked them to add `http://localhost:8080` as a redirect URI. In the current Google Cloud Console flow, explicitly configuring an authorized redirect URI is done with a **Web application** OAuth client.

## Changes

- Change OAuth client type from **Desktop app** to **Web application**
- Add clearer Google Cloud Console navigation:
  - Google Auth Platform -> Clients
  - Create client
  - Authorized redirect URIs
- Clarify that `http://localhost:8080` must be added exactly as an authorized redirect URI
- Improve wording around test users and OAuth consent screen setup

## Why

Using **Desktop app** while requiring a manually configured redirect URI is confusing and can lead to OAuth setup failures, especially `redirect_uri_mismatch` errors.

This update makes the migration guide match the actual Google Cloud Console setup flow for the parity tool redirect URI.