### PR TITLE
fix: catch and warn on invalid/corrupted token file JSON

### DIFF
--- a/Fitbit_Fetch.py
+++ b/Fitbit_Fetch.py
@@ -488,9 +488,24 @@ def refresh_google_tokens(client_id, client_secret, refresh_token):
     logging.info("Google token refresh successful!")
     return access_token, new_refresh_token
 
+
+def invalid_token_file_error():
+    return ValueError(
+        f"Token file at {TOKEN_FILE_PATH} is corrupted or invalid. Expected a valid JSON in format:\n"
+        '{ "refresh_token": "your_refresh_token" }'
+    )
+
+
 def load_tokens_from_file():
     with open(TOKEN_FILE_PATH, "r") as file:
-        tokens = json.load(file)
+        try:
+            tokens = json.load(file)
+        except json.JSONDecodeError as e:
+            raise invalid_token_file_error() from e
+
+        if not isinstance(tokens, dict):
+            raise invalid_token_file_error()
+
         provider = (tokens.get("provider") or "fitbit").lower()
         return tokens.get("access_token"), tokens.get("refresh_token"), provider
 


### PR DESCRIPTION
### Added:
- Adds error handling for invalid/corrupted token files.
- Logs a descriptive error about the expected format needed for the initial setup.

---
👀  for context - I ran into this issue when I was setting up the project for the first time, and from the logs, it was not very clear what the problem was, as I just assumed pasting in the raw token would be enough.

This error message and handling should prevent this scenario from happening in the future for others :)